### PR TITLE
Gun Path Renames (Argos, Rafale and Rat Man)

### DIFF
--- a/code/datums/autolathe/guns.dm
+++ b/code/datums/autolathe/guns.dm
@@ -59,7 +59,7 @@
 
 /datum/design/autolathe/gun/rafale
 	name = "Seinemetall Defense GmbH SHG .40 \"Rafale\""
-	build_path = /obj/item/gun/projectile/silenced
+	build_path = /obj/item/gun/projectile/rafale
 
 /datum/design/autolathe/gun/mk58_wood
 	name = "OT HG .40 \"Mk58\""

--- a/code/datums/autolathe/guns.dm
+++ b/code/datums/autolathe/guns.dm
@@ -94,9 +94,9 @@
 	name = "SA HG .50 Kurz \"Lamia\""
 	build_path = /obj/item/gun/projectile/lamia
 
-/datum/design/autolathe/gun/scoped_lamia
+/datum/design/autolathe/gun/argos
 	name = "Seinemetall Defense GmbH HG .50 Kurz \"Argos\" Advanced"
-	build_path = /obj/item/gun/projectile/lamia/scoped
+	build_path = /obj/item/gun/projectile/lamia/argos
 
 /datum/design/autolathe/gun/basilisk
 	name = "H&S HG .50 Kurz \"Basilisk\""

--- a/code/game/objects/items/weapons/storage/blackshield_kits.dm
+++ b/code/game/objects/items/weapons/storage/blackshield_kits.dm
@@ -305,7 +305,7 @@
 	desc = "A kit containing a highly specialized .50 Kurz pistol with smart-linked optics and stabilizers."
 
 	populate_contents()
-		new /obj/item/gun/projectile/lamia/scoped(src)
+		new /obj/item/gun/projectile/lamia/argos(src)
 		new /obj/item/ammo_magazine/kurz_50(src)
 		new /obj/item/ammo_magazine/kurz_50(src)
 		new /obj/item/clothing/accessory/holster/leg(src)

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -530,7 +530,7 @@ obj/item/storage/pouch/large_generic/advmedic/populate_contents()
 		/obj/item/gun/projectile/mk58,
 		/obj/item/gun/projectile/revolver/lemant,
 		/obj/item/gun/projectile/olivaw,
-		/obj/item/gun/projectile/silenced,
+		/obj/item/gun/projectile/rafale,
 		/obj/item/gun/projectile/ladon,
 		/obj/item/gun/projectile/glock,
 		/obj/item/gun/projectile/that_gun,

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -177,7 +177,7 @@
 	desc = ".40 suppressed handgun and its kit."
 
 /obj/item/storage/box/syndie_kit/pistol/populate_contents()
-	new /obj/item/gun/projectile/silenced(src)
+	new /obj/item/gun/projectile/rafale(src)
 	new /obj/item/ammo_magazine/magnum_40/hv(src)
 	new /obj/item/ammo_magazine/magnum_40/hv(src)
 	new /obj/item/clothing/glasses/sunglasses(src)

--- a/code/game/objects/random/guns.dm
+++ b/code/game/objects/random/guns.dm
@@ -167,7 +167,7 @@
 				/obj/item/gun/projectile/colt/ten = 2,\
 				/obj/item/gun/projectile/automatic/nordwind/strelki = 0.3, \
 				/obj/item/gun/projectile/boltgun/lever = 1, \
-				/obj/item/gun/projectile/lamia/scoped = 1,\
+				/obj/item/gun/projectile/lamia/argos = 1,\
 				/obj/item/gun/projectile/revolver/deckard = 0.4,\
 				/obj/item/gun/projectile/makarov = 1.5,\
 				/obj/item/gun/energy/lasercannon = 0.5,\

--- a/code/game/objects/random/guns.dm
+++ b/code/game/objects/random/guns.dm
@@ -162,7 +162,7 @@
 				/obj/item/gun/projectile/basilisk = 2,\
 				/obj/item/gun/projectile/automatic/survivalrifle = 1,\
 				/obj/item/gun/projectile/revolver/tacticool_revolver = 1,\
-				/obj/item/gun/projectile/silenced = 2,\
+				/obj/item/gun/projectile/rafale = 2,\
 				/obj/item/gun/projectile/revolver/mistral = 2,\
 				/obj/item/gun/projectile/colt/ten = 2,\
 				/obj/item/gun/projectile/automatic/nordwind/strelki = 0.3, \

--- a/code/game/objects/random/oddities.dm
+++ b/code/game/objects/random/oddities.dm
@@ -125,7 +125,7 @@
 				/obj/item/gun/projectile/deaglebolt = 1,
 				/obj/item/gun/projectile/revolver/mistral/elite = 1,
 				/obj/item/gun/projectile/shotgun/doublebarrel/bluecross_shotgun = 1,
-				/obj/item/gun/projectile/silenced/rat = 1,
+				/obj/item/gun/projectile/rafale/ratman = 1,
 				/obj/item/gun/projectile/automatic/maxim/replica = 1,
 				/obj/item/gun/projectile/revolver/deacon = 1,
 				/obj/item/gun/projectile/clarissa/devil_eye = 1,

--- a/code/modules/cargo/packs_security.dm
+++ b/code/modules/cargo/packs_security.dm
@@ -117,7 +117,7 @@
 
 /datum/supply_pack/smoothoperator
 	name = "LS Smooth Operator Specialty Crate"
-	contains = list(/obj/item/gun/projectile/silenced, //375
+	contains = list(/obj/item/gun/projectile/rafale, //375
 					/obj/item/ammo_magazine/magnum_40,
 					/obj/item/ammo_magazine/magnum_40,
 					/obj/item/clothing/shoes/syndigaloshes,

--- a/code/modules/projectiles/guns/oddity_items.dm
+++ b/code/modules/projectiles/guns/oddity_items.dm
@@ -128,7 +128,7 @@
 		)
 	serial_type = "BlueCross"
 
-/obj/item/gun/projectile/silenced/rat
+/obj/item/gun/projectile/rafale/ratman
 	name = "\"Rat Man\" silenced pistol"
 	desc = "An anomalous weapon created by an unknown person (or group?), their work marked by a blue cross, these items are known to vanish and reappear when left alone. \
 	A spray painted decal of a rat man with a grinning face has been placed on the grip, the deadliest killers are often those ignored or underestimated by others after all. \

--- a/code/modules/projectiles/guns/projectile/pistol/lamia.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/lamia.dm
@@ -61,7 +61,7 @@
 	serial_type = "Sol Fed"
 	serial_shown = TRUE
 
-/obj/item/gun/projectile/lamia/scoped
+/obj/item/gun/projectile/lamia/argos
 	name = "\"Argos\" advanced heavy pistol"
 	desc = "Seinemetall Defense GmbH handgun .50 Kurz \"Argos\" Based on the \"Lamia\" heavy pistol, it's fit for high ranking enforcers; fitted with a smart-linked optic and stabilizer. Uses .50 Kurz."
 	icon_state = "scoped_lamia"

--- a/code/modules/projectiles/guns/projectile/pistol/silenced.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/silenced.dm
@@ -1,4 +1,4 @@
-/obj/item/gun/projectile/silenced
+/obj/item/gun/projectile/rafale
 	name = "\"Rafale\" silenced pistol"
 	desc = "A high quality, specialty handgun exclusively produced (as the markings so proudly state) by Seinemetall Defense GmbH. Commonly used by police and SWAT teams during stealth operations. Uses .40 Auto-Mag. Has an integrated silencer which cannot be removed."
 	icon = 'icons/obj/guns/projectile/rafale.dmi'
@@ -23,7 +23,7 @@
 	wield_delay = 0.4 SECOND
 	wield_delay_factor = 0.4 // 40 vig
 
-/obj/item/gun/projectile/silenced/update_icon()
+/obj/item/gun/projectile/rafale/update_icon()
 	..()
 
 	var/iconstring = initial(icon_state)
@@ -36,6 +36,6 @@
 
 	icon_state = iconstring
 
-/obj/item/gun/projectile/silenced/Initialize()
+/obj/item/gun/projectile/rafale/Initialize()
 	. = ..()
 	update_icon()

--- a/code/modules/stashes/stash_types/ninja.dm
+++ b/code/modules/stashes/stash_types/ninja.dm
@@ -10,7 +10,7 @@
 	contents_list_base = list(/obj/item/storage/box/smokes)
 	contents_list_random = list(
 		/obj/item/storage/box/anti_photons = 60,
-		/obj/item/gun/projectile/silenced = 50,
+		/obj/item/gun/projectile/rafale = 50,
 		/obj/item/material/star/uranium = 70,
 		/obj/item/tool/sword/katana = 20,
 		/obj/item/rig_module/modular_injector/medical/preloaded = 90, //Weakest chem dispenser rig

--- a/maps/_DeepForest/map/_Deep_Forest.dmm
+++ b/maps/_DeepForest/map/_Deep_Forest.dmm
@@ -31239,7 +31239,7 @@
 /area/asteroid/rogue)
 "uQx" = (
 /obj/structure/closet/crate/serbcrate,
-/obj/item/gun/projectile/silenced,
+/obj/item/gun/projectile/rafale,
 /turf/simulated/floor/wood/wild4,
 /area/asteroid/rogue)
 "uQz" = (


### PR DESCRIPTION
## About The Pull Request
Changes the path names for the Argos, Rafale and Rat Man so that they're easier to find both in-code and in-game for admins

## Changelog
- Changed the Argos path name from lamia/scoped to lamia/argos
- Changed the Argos autolathe path name from gun/scoped_lamia to gun/argos
- Changed the Rafale path name from silenced to rafale
- Changed the Rat Man path name from silenced/rat to rafale/ratman